### PR TITLE
chore: chrome polish — navbar, time-scrubber, /blog cards, post layout

### DIFF
--- a/src/components/sky/TimeScrubber.astro
+++ b/src/components/sky/TimeScrubber.astro
@@ -24,6 +24,9 @@ const showGeo = !!(placeName || (latStr && lonStr));
 		<input type="range" id="sky-time" min="0" max="1439" step="1" aria-label="Time" />
 		<button type="button" id="sky-now" class="now-btn" title="Snap back to live time">Now</button>
 	</div>
+	<div class="credit">
+		Stars: <a href="https://codeberg.org/astronexus/hyg" target="_blank" rel="noopener noreferrer">HYG v3</a> (CC BY-SA 2.5)
+	</div>
 </aside>
 
 <style>
@@ -49,14 +52,20 @@ const showGeo = !!(placeName || (latStr && lonStr));
 		display: flex;
 		gap: 0.4rem;
 		align-items: baseline;
+		font: inherit;
 		font-size: 0.7rem;
-		opacity: 0.75;
+		font-variant-numeric: normal;
+		opacity: 0.95;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
+	.time-scrubber .geo {
+		justify-content: center;
+		text-align: center;
+	}
 	.time-scrubber .geo .place { font-weight: 600; opacity: 0.95; }
-	.time-scrubber .geo .sep { opacity: 0.4; }
+	.time-scrubber .geo .sep { opacity: 0.95; }
 	.time-scrubber .time-row {
 		display: flex;
 		gap: 0.5rem;
@@ -73,7 +82,7 @@ const showGeo = !!(placeName || (latStr && lonStr));
 	}
 	.time-scrubber .time-readout {
 		font-variant-numeric: tabular-nums;
-		opacity: 0.85;
+		opacity: 0.95;
 		min-width: 3.2em;
 		text-align: center;
 	}
@@ -129,6 +138,17 @@ const showGeo = !!(placeName || (latStr && lonStr));
 		cursor: pointer;
 	}
 	.time-scrubber .now-btn:hover { background: rgba(255, 255, 255, 0.1); }
+	.time-scrubber .credit {
+		font-size: 0.65rem;
+		opacity: 0.95;
+		text-align: right;
+	}
+	.time-scrubber .credit a {
+		color: inherit;
+		text-decoration: underline;
+		text-decoration-color: rgba(255, 255, 255, 0.3);
+	}
+	.time-scrubber .credit a:hover { opacity: 1; text-decoration-color: currentColor; }
 </style>
 
 <script>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -32,6 +32,9 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
 </SiteLayout>
 
 <style>
+	.post {
+		padding-bottom: var(--space-6);
+	}
 	.post .hero-image img {
 		display: block;
 		margin: 0 auto 1.5rem;

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -44,7 +44,7 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 				width: fit-content;
 				max-width: calc(100% - 2rem);
 				margin: 2.25rem auto 0;
-				padding: 0.25rem 0.7rem;
+				padding: 0.45rem 1rem;
 				background: var(--content-bg, rgba(255, 255, 255, 0.92));
 				color: var(--content-fg, #0f1219);
 				border: 1px solid var(--content-border, rgba(0, 0, 0, 0.08));
@@ -70,8 +70,8 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 				display: inline-flex;
 				align-items: center;
 				margin: 0;
-				padding: 0 3rem 0 0.4rem;
-				font-size: 1rem;
+				padding: 0 3.5rem 0 0.5rem;
+				font-size: 1.25rem;
 				font-weight: 600;
 				line-height: 1;
 				opacity: 0.85;
@@ -80,17 +80,17 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 			html.site header nav a {
 				display: inline-flex;
 				align-items: center;
-				padding: 0.3rem 0.55rem;
+				padding: 0.45rem 0.8rem;
 				border-bottom: none;
 				box-shadow: none;
 				border-radius: 999px;
 				color: inherit;
-				font-size: 1.1rem;
+				font-size: 1.35rem;
 				transition: background 200ms ease;
 			}
 			html.site header nav a:hover { background: rgba(0, 0, 0, 0.05); }
 			html.site header nav a.active {
-				padding: 0.3rem 0.95rem;
+				padding: 0.45rem 1.2rem;
 				margin: 0 -0.4rem;
 				background: var(--content-fg, #0f1219);
 				color: var(--content-bg-fg, #fff);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -30,8 +30,9 @@ const posts = (await getCollection("blog"))
 		flex-direction: column;
 		gap: 1.25rem;
 		list-style: none;
-		margin: 0;
+		margin: 0 auto;
 		padding: 0;
+		max-width: 900px;
 	}
 	.post-card {
 		border-radius: 10px;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -52,7 +52,7 @@ const posts = (await getCollection("blog"))
 		display: flex;
 		flex-direction: column;
 		gap: 0;
-		padding: 1.1rem 1.4rem 0.55rem !important;
+		padding: 1.1rem 1.8rem 0.55rem !important;
 		text-decoration: none !important;
 		color: inherit !important;
 		background: none !important;
@@ -71,6 +71,6 @@ const posts = (await getCollection("blog"))
 		font-variant-numeric: tabular-nums;
 	}
 	@media (max-width: 720px) {
-		.post-card a { padding: 0.75rem 1rem !important; }
+		.post-card a { padding: 0.75rem 1.25rem !important; }
 	}
 </style>


### PR DESCRIPTION
## Summary
Small chrome polish across the navbar, time-scrubber, blog index, and blog post layout.

**Navbar**
- Scale up the navbar pill: larger pill padding, bigger title (`1rem → 1.25rem`) and link font (`1.1rem → 1.35rem`) with proportional padding bumps.

**Time scrubber (bottom control)**
- Credit the HYG v3 star catalog (CC BY-SA 2.5) with a link to the upstream repo on Codeberg.
- Match the date's font to the location: inherit body font and turn off `tabular-nums` so digits stop falling back to a different face from the place-name letters.
- Lift all secondary text (`.geo`, `.sep`, `.time-readout`, `.credit`) to `opacity: 0.95` for parity with the place name and better legibility on the glass background.
- Center the first (geo) row.

**/blog index**
- Slightly increase horizontal padding on post cards: `1.4rem → 1.8rem` (desktop), `1rem → 1.25rem` (mobile).
- Cap the post-list at `max-width: 900px` (centered) so cards aren't as wide as the 980px main container.

**Blog post pages**
- Add 6rem of bottom padding to the `.post` layout so the last paragraph isn't flush against the card edge.

## Test plan
- [ ] `pnpm dev` and confirm the navbar pill renders larger across breakpoints; active link highlight still aligns.
- [ ] Bottom control: location row centered, slider row, and a small "Stars: HYG v3 (CC BY-SA 2.5)" credit link below.
- [ ] Date and location render in the same font weight/face (no digit fallback mismatch).
- [ ] HYG link opens https://codeberg.org/astronexus/hyg in a new tab.
- [ ] Scrub the slider and press "Now" — behavior unchanged.
- [ ] Visit `/blog`: post-card titles have more breathing room; the list is centered and clearly narrower than the main column on wide screens.
- [ ] Open any blog post and confirm there's clear space below the last paragraph before the card's bottom edge.
