### PR TITLE
ci: deploy to Cloudflare Pages and pin install with --frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=debuggingfuture-com --branch=master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy to Cloudflare Pages
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  deployments: write
 
 concurrency:
-  group: "pages"
+  group: cloudflare-pages
   cancel-in-progress: false
 
 env:
@@ -23,8 +22,9 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    name: Build and deploy
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -36,24 +36,13 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build with Astro
         run: pnpm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=debuggingfuture-com --branch=master


### PR DESCRIPTION
## Summary
Fixes the broken deploy pipeline by switching CI from GitHub Pages → Cloudflare Pages, and stops the install step from floating to a newer Astro that breaks the lockfile-pinned build.

### Root cause
- #4 added `adapter: cloudflare(...)` to `astro.config.mjs:15`, so `pnpm run build` now emits a Cloudflare Pages full-stack bundle (`dist/_worker.js/...`) instead of a static site. GitHub Pages can't serve that.
- `pnpm install` (no `--frozen-lockfile`) re-resolves Astro inside the `^5.5.4` range. Newer 5.x dropped the `experimental.session` flag that the lockfile-pinned 5.5.4 still requires when paired with `@astrojs/cloudflare`. That's what produced the "Invalid or outdated experimental feature" error in the failing run on master.

### Fix
- Replace the GH Pages workflow with a Cloudflare Pages deploy via `cloudflare/wrangler-action@v3` (`pages deploy dist --branch=master`).
- Pin install with `pnpm install --frozen-lockfile` so CI builds with the same Astro the lockfile resolves locally.

## Required before merging
1. Create a Cloudflare Pages project named **`debuggingfuture-com`** in the target Cloudflare account, with `master` as the production branch. (Adjust `--project-name=` in `.github/workflows/ci.yml` if you pick a different name.)
2. Repo **secret**: `CLOUDFLARE_API_TOKEN` (Cloudflare API token with `Account → Cloudflare Pages → Edit`).
3. Repo **variable** (not secret): `CLOUDFLARE_ACCOUNT_ID`.
4. Move the `debuggingfuture.com` custom domain over to the new Cloudflare Pages project (DNS already proxies through Cloudflare per `curl -I` of the apex).

## Notes / follow-ups
- The geo-personalization middleware (`src/middleware.ts`) still won't run at request time because every page is statically prerendered (`output: "static"` with no `prerender = false`). This PR does not change that — it's tracked as a separate concern.
- The `CNAME` file is now redundant (it was for GH Pages). Left in place as harmless noise; can remove in a follow-up once Cloudflare Pages is confirmed live.

## Test plan
- [ ] Set the secret + variable + project, then trigger a `workflow_dispatch` run.
- [ ] First successful run shows a Cloudflare Pages preview URL in the action logs.
- [ ] After the custom domain is moved, `curl -I https://debuggingfuture.com` shows fresh `last-modified` reflecting the new deploy.
