### PR TITLE
ci: bump pnpm setup to v10 to match lockfileVersion 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
Follow-up to #6. The first Cloudflare-Pages deploy run still failed before reaching wrangler:

```
WARN  Ignoring not compatible lockfile at .../pnpm-lock.yaml
ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
```

Root cause: `pnpm-lock.yaml` is `lockfileVersion: '9.0'` (emitted by pnpm 9+), but `.github/workflows/ci.yml` was pinning `pnpm/action-setup@v4` to `version: 8`. pnpm 8 silently ignores v9 lockfiles, then `--frozen-lockfile` errors out with no lockfile available.

## Change
Bump the action's `version` from `8` → `10`. Local pnpm is 10.x, so this just brings CI in line.

## Test plan
- [ ] Once merged, watch the next master deploy go through `pnpm install --frozen-lockfile` cleanly and reach the wrangler `pages deploy` step.
- [ ] Confirm the Cloudflare Pages deploy URL appears in the run logs.

Failing run for reference: https://github.com/debuggingfuture/debuggingfuture.com/actions/runs/25227916488
