### PR TITLE
fix(build): use Cloudflare adapter's passthrough image service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,10 @@ import remarkBreaks from "remark-breaks";
 export default defineConfig({
 	site: "https://debuggingfuture.com",
 	output: "static",
-	adapter: cloudflare({ platformProxy: { enabled: true } }),
+	adapter: cloudflare({
+		platformProxy: { enabled: true },
+		imageService: "passthrough",
+	}),
 	experimental: { session: true },
 	integrations: [
 		mdx({


### PR DESCRIPTION
## Summary
Latest deploy ([run](https://github.com/debuggingfuture/debuggingfuture.com/actions/runs/25228442115)) failed at "generating optimized images" with `MissingSharp: Could not find Sharp`. Sharp's native binary couldn't be resolved from the bundled chunk path (`dist/_worker.js/chunks/sharp_*.mjs`).

## Root cause
`@astrojs/cloudflare` defaults `imageService` to `"compile"` (`utils/image-config.js:11`), which calls `sharpImageService()` and **silently overrides** the `passthroughImageService()` already set in `astro.config.mjs#image.service`. The build then bundles sharp into the worker output, where it can't load on CI.

## Fix
Tell the adapter explicitly:

```js
adapter: cloudflare({
  platformProxy: { enabled: true },
  imageService: "passthrough",
}),
```

Honours the existing intent: no transforms, no sharp, originals copied as-is.

## Test plan
- [x] Local clean build (`rm -rf .astro dist && pnpm run build`) completes cleanly with no sharp warnings.
- [ ] Once merged, master deploy passes the build step and reaches the wrangler `pages deploy` action.
- [ ] If/when the Cloudflare project + secrets/vars are in place, the deploy URL shows up in the run logs.
