### PR TITLE
fix(ui): mobile navbar overflow + hide Substack widget

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -56,13 +56,14 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 			html.site header nav {
 				display: flex;
 				align-items: center;
-				justify-content: space-between;
+				justify-content: center;
 				gap: 0.4rem;
 				flex-wrap: nowrap;
 			}
 			html.site header nav .internal-links {
 				display: flex;
 				align-items: center;
+				justify-content: center;
 				gap: 0.4rem;
 				flex-wrap: nowrap;
 			}
@@ -97,6 +98,25 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 				font-weight: 500;
 				text-decoration: none;
 			}
+			@media (max-width: 640px) {
+				html.site header {
+					width: auto;
+					max-width: calc(100% - 1rem);
+					margin: 1rem auto 0;
+					padding: 0.35rem 0.6rem;
+				}
+				html.site header nav { gap: 0.2rem; }
+				html.site header nav h2 { display: none; }
+				html.site header nav .internal-links { gap: 0.15rem; }
+				html.site header nav a {
+					padding: 0.35rem 0.45rem;
+					font-size: 0.95rem;
+				}
+				html.site header nav a.active {
+					padding: 0.35rem 0.6rem;
+					margin: 0 -0.15rem;
+				}
+			}
 		</style>
 		<style is:global>
 			html.site main.site-main {
@@ -123,6 +143,11 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 			html.site article.content-card p {
 				margin: 0 0 var(--space-2);
 				line-height: var(--text-leading);
+			}
+			html.site article.content-card h1 {
+				font-size: clamp(1.5rem, 8vw, 3.052em);
+				white-space: nowrap;
+				overflow-wrap: normal;
 			}
 			html.site article.content-card h2,
 			html.site article.content-card h3,

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -175,6 +175,9 @@ const inlineVarsBlock = `:root {\n${Object.entries(baselineSky.cssVars)
 				padding: 0 1px;
 			}
 			@media (max-width: 720px) {
+				html.site main.site-main {
+					margin: 3rem auto 4rem;
+				}
 				html.site article.content-card {
 					padding: var(--space-3) var(--space-2);
 				}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,5 @@
 ---
 import SiteLayout from "../layouts/SiteLayout.astro";
-import SubstackWidget from "../components/SubstackWidget.astro";
 import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
 import * as IntroPost from "../content/intro.md";
 ---
@@ -10,7 +9,6 @@ import * as IntroPost from "../content/intro.md";
 	<IntroPost.Content />
 	<hr />
 	<div class="container">
-		Subscribe via <a href="https://debuggingfuture.com/atom.xml">RSS/Atom</a> or substack
-		<SubstackWidget />
+		Subscribe via <a href="https://debuggingfuture.com/atom.xml">RSS/Atom</a>
 	</div>
 </SiteLayout>


### PR DESCRIPTION
## Summary
- Fix navbar overflow on mobile: pill header rendered wider than the viewport on narrow screens, clipping the right-most nav links and forcing horizontal scroll.
- Add a `@media (max-width: 640px)` block in `SiteLayout.astro` that shrinks header padding, tightens link padding/font-size, and **hides the "Debug 未來" site title on mobile** to free horizontal space.
- Switch nav layout from `space-between` to `justify-content: center` so the links cluster centered in the pill.
- Constrain the home `<h1>@debuggingfuture</h1>` to a single row via `clamp(1.5rem, 8vw, 3.052em)` + `white-space: nowrap`.
- Tighten `main.site-main` margin on ≤720px viewports (5rem/10rem → 3rem/4rem) so the content card doesn't sit in a sea of whitespace below the fold.
- Hide the Substack subscribe widget on `/` for now; the RSS/Atom link remains.

## Test plan
- [x] `pnpm build` passes
- [x] Loaded `/` in dev server, confirmed header renders, h1 is single-line, Substack widget gone
- [ ] Verify in mobile viewport (≤640px) that the navbar fits within the viewport with no horizontal overflow and the site title is hidden
- [ ] Verify desktop (≥641px) layout is unchanged (site title visible)
- [ ] Verify h1 stays one line at 320–360px viewports
- [ ] Verify content card has tighter bottom whitespace on mobile
