### PR TITLE
ci: add build-output smoke test, gate deploy on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Deploy to Cloudflare Pages
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -10,7 +12,7 @@ permissions:
   deployments: write
 
 concurrency:
-  group: cloudflare-pages
+  group: cloudflare-pages-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -22,9 +24,9 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    name: Build and deploy
+    name: Build and smoke test
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm
@@ -40,6 +42,52 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build with Astro
         run: pnpm run build
+      - name: Smoke test build output
+        run: |
+          set -euo pipefail
+          required=(
+            "dist/index.html"
+            "dist/about/index.html"
+            "dist/blog/index.html"
+            "dist/hack/index.html"
+            "dist/life/index.html"
+            "dist/rss.xml"
+            "dist/sitemap-index.xml"
+            "dist/_worker.js"
+          )
+          missing=0
+          for f in "${required[@]}"; do
+            if [[ ! -s "$f" ]]; then
+              echo "::error::missing or empty: $f"
+              missing=1
+            fi
+          done
+          if [[ "$missing" -ne 0 ]]; then exit 1; fi
+          grep -q "<title>Debug 未來</title>" dist/index.html \
+            || { echo "::error::homepage title missing"; exit 1; }
+          grep -q "</rss>" dist/rss.xml \
+            || { echo "::error::rss.xml malformed"; exit 1; }
+          echo "smoke test passed"
+      - name: Upload build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Pages
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,31 +43,7 @@ jobs:
       - name: Build with Astro
         run: pnpm run build
       - name: Smoke test build output
-        run: |
-          set -euo pipefail
-          required=(
-            "dist/index.html"
-            "dist/about/index.html"
-            "dist/blog/index.html"
-            "dist/hack/index.html"
-            "dist/life/index.html"
-            "dist/rss.xml"
-            "dist/sitemap-index.xml"
-            "dist/_worker.js"
-          )
-          missing=0
-          for f in "${required[@]}"; do
-            if [[ ! -s "$f" ]]; then
-              echo "::error::missing or empty: $f"
-              missing=1
-            fi
-          done
-          if [[ "$missing" -ne 0 ]]; then exit 1; fi
-          grep -q "<title>Debug 未來</title>" dist/index.html \
-            || { echo "::error::homepage title missing"; exit 1; }
-          grep -q "</rss>" dist/rss.xml \
-            || { echo "::error::rss.xml malformed"; exit 1; }
-          echo "smoke test passed"
+        run: pnpm run smoke
       - name: Upload build artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"dev": "astro dev",
 		"build": "astro build",
 		"preview": "astro preview",
+		"smoke": "node scripts/smoke.mjs",
 		"astro": "astro",
 		"check:fix": "biome check . --write --no-errors-on-unmatched"
 	},

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { readFile, stat } from "node:fs/promises";
+import { argv, exit } from "node:process";
+
+const distDir = argv[2] ?? "dist";
+
+const requiredFiles = [
+	"index.html",
+	"about/index.html",
+	"blog/index.html",
+	"hack/index.html",
+	"life/index.html",
+	"rss.xml",
+	"sitemap-index.xml",
+	"_worker.js/index.js",
+	"_routes.json",
+];
+
+const contentChecks = [
+	{
+		file: "index.html",
+		needle: "<title>Debug 未來</title>",
+		label: "homepage title",
+	},
+	{
+		file: "rss.xml",
+		needle: "</rss>",
+		label: "rss closing tag",
+	},
+];
+
+const failures = [];
+
+for (const rel of requiredFiles) {
+	const path = `${distDir}/${rel}`;
+	try {
+		const s = await stat(path);
+		if (!s.isFile() || s.size === 0) {
+			failures.push(`empty or not a file: ${path}`);
+		}
+	} catch {
+		failures.push(`missing: ${path}`);
+	}
+}
+
+for (const { file, needle, label } of contentChecks) {
+	const path = `${distDir}/${file}`;
+	try {
+		const body = await readFile(path, "utf8");
+		if (!body.includes(needle)) {
+			failures.push(`${label} not found in ${path} (expected substring: ${needle})`);
+		}
+	} catch (err) {
+		failures.push(`could not read ${path}: ${err.message}`);
+	}
+}
+
+if (failures.length > 0) {
+	for (const f of failures) console.error(`smoke: ${f}`);
+	console.error(`smoke: ${failures.length} check(s) failed`);
+	exit(1);
+}
+
+console.log(`smoke: ${requiredFiles.length} files + ${contentChecks.length} content checks passed`);


### PR DESCRIPTION
## Summary

Adds a build-output smoke test to CI and uses it to gate the Cloudflare Pages deploy. The workflow now runs on PRs too, so build breakage is caught before merge instead of mid-deploy.

## How it works

- **`scripts/smoke.mjs`** — a Node ESM script that asserts the build output is sane. Runnable locally as `pnpm run smoke`, same script CI runs:
  - Required files exist and are non-empty: homepage, `about/`, `blog/`, `hack/`, `life/`, `rss.xml`, `sitemap-index.xml`, `_worker.js/index.js` (the Cloudflare worker entry), `_routes.json`.
  - `dist/index.html` contains the site title (`<title>Debug 未來</title>`).
  - `dist/rss.xml` is well-formed (closing `</rss>`).
- **`build` job** runs on PRs and master push: install deps → `pnpm run build` → `pnpm run smoke`. On master push the build output is uploaded as an artifact.
- **`deploy` job** runs only on master push, `needs: build`, downloads the same artifact, and ships it to Cloudflare Pages. The bytes that get deployed are exactly the bytes that passed the smoke test.
- `concurrency.group` is now per-ref so PR builds don't queue behind master deploys.

Keeping the verification in a Node script (rather than an inline shell block in the YAML) means there's no shell-quoting surface, the same check runs in CI and locally, and edits go through a real file instead of a multiline `run:` block. It also surfaced a quirk: the Cloudflare adapter emits `_worker.js` as a *directory*, not a file — the script asserts on the real worker entry (`_worker.js/index.js`).

## Test plan

- [x] `pnpm run smoke` passes against a fresh local build.
- [x] Smoke script exits non-zero with clear errors when files are missing (verified with a bogus dist path).
- [ ] CI build job passes on this PR.
- [ ] After merge: master build → deploy chain runs and Cloudflare Pages deploy succeeds with the artifact handoff.
- [ ] Verify https://debuggingfuture.com/ still serves after the next master deploy.
