### PR TITLE
ci: set up pnpm/node in the deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - uses: actions/checkout@v4
+      # wrangler-action installs wrangler with the repo's package manager
+      # (pnpm-lock.yaml => pnpm), so pnpm must be on PATH in this job too.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The `deploy` job has never succeeded — every push to `master` fails with `Unable to locate executable file: pnpm`, so nothing has actually shipped from Actions.

## Insight

`cloudflare/wrangler-action` installs wrangler using **the repo's** package manager — it sees `pnpm-lock.yaml` and shells out to `pnpm`. The `build` job sets up pnpm + Node; the `deploy` job only checks out and downloads the artifact, so `pnpm` isn't on PATH there.

This is not a regression from a recent PR — it's been broken since the workflow landed. Cloudflare Pages **Git integration is off** for `debuggingfuture-com` (`wrangler pages project list` → `Git integration: No`), and the newest production deployment is `dde8487`, a month old. Actions is the only deploy path, and it hasn't run to completion, so the last two merges never reached production.

## Rationale

Fix rather than delete: with Git integration off there's no fallback deployer. Adding the two setup steps is the minimal change that makes `wrangler-action` able to resolve wrangler.

## Verification

The `deploy` job is gated on `push` + `refs/heads/master`, so **PR CI cannot exercise it** — only `build` runs here. After merge, the `master` run is the real test; the live site must be checked by page *content*, not status code (the Pages project currently returns `200` for any path, including bogus ones).
